### PR TITLE
feat: add support to configure target architecture

### DIFF
--- a/lua/dap-cs.lua
+++ b/lua/dap-cs.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local default_config = {
+  architecture = 'x86_64',
   netcoredbg = {
     path = "netcoredbg",
   },
@@ -144,12 +145,14 @@ local setup_configuration = function(dap, dap_utils, config)
         local current_working_dir = vim.fn.getcwd()
         return select_dll(current_working_dir) or dap.ABORT
       end,
+      targetArchitecture = config.architecture
     },
     {
       type = "coreclr",
       name = "Attach",
       request = "attach",
       processId = dap_utils.pick_process,
+      targetArchitecture = config.architecture
     },
 
     {
@@ -160,6 +163,7 @@ local setup_configuration = function(dap, dap_utils, config)
         local current_working_dir = vim.fn.getcwd()
         return smart_pick_process(dap_utils, current_working_dir) or dap.ABORT
       end,
+      targetArchitecture = config.architecture
     },
   }
 


### PR DESCRIPTION
# Description

This PR adds a new configuration to set the target architecture and avoid the error `Failed command 'configurationDone': 0x80131c3c` when running on M1 Silicon arm64