### PR TITLE
Fix typo

### DIFF
--- a/lua/dap-cs.lua
+++ b/lua/dap-cs.lua
@@ -170,7 +170,7 @@ local setup_configuration = function(dap, dap_utils, config)
 
   for _, dap_config in ipairs(config.dap_configurations) do
     if dap_config.type == "coreclr" then
-      table.insert(dap.configurations.cs, config)
+      table.insert(dap.configurations.cs, dap_config)
     end
   end
 end


### PR DESCRIPTION
Fixed a typo that resulted in the plugins' config being inserted into the dap configurations table for each element declared in the `dap_configurations` key.