### PR TITLE
fix: truncate unwanted characters from dll path when there are multiple dlls

### DIFF
--- a/lua/dap-cs.lua
+++ b/lua/dap-cs.lua
@@ -48,7 +48,8 @@ local file_selection = function(cmd, opts)
 
   local result = results[1]
   if #results > 1 then
-    result = display_options(opts.multiple_title_message, results)
+    result = string.sub(display_options(opts.multiple_title_message, results), 4, -1)
+
   end
 
   return result


### PR DESCRIPTION
When there are multiple dlls to choose from inside the project's bin folder, the choosen dll's path string is returned by display_options in the form of "i: dllpath" but is not truncated back to "dllpath" before appending it to the full path inside select_dll.